### PR TITLE
SLVS-681 S2333 - "unsafe" context is redundant

### DIFF
--- a/src/SonarLint.Extra/Rules.Description/S2333.html
+++ b/src/SonarLint.Extra/Rules.Description/S2333.html
@@ -3,6 +3,8 @@
     <ul>
         <li><code>partial</code> on type declarations that are completely defined in one place</li>
         <li><code>sealed</code> on members of <code>sealed</code> classes</li>
+        <li><code>unsafe</code> method or block inside construct already marked with <code>unsafe</code>, or when there are no <code>unsafe</code>
+        constructs in the block</li>
     </ul>
 </p>
 

--- a/src/Tests/SonarLint.UnitTest/TestCases/RedundantModifier.Fixed.cs
+++ b/src/Tests/SonarLint.UnitTest/TestCases/RedundantModifier.Fixed.cs
@@ -49,4 +49,88 @@ interface PartialInterface //Noncompliant
             return "Test";
         }
     }
+
+    unsafe class UnsafeClass
+    {
+        int* pointer;
+    }
+
+    class UnsafeClass2 // Noncompliant
+    {
+        int num;
+    }
+    class UnsafeClass3 // Noncompliant
+    {
+        void M() // Noncompliant
+        {
+
+        }
+    }
+
+    class Class4
+    {
+        unsafe interface MyInterface
+        {
+            int* Method(); // Noncompliant
+        }
+
+        private unsafe delegate void MyDelegate(int* p);
+        private delegate void MyDelegate2(int i); // Noncompliant
+
+        class Inner { } // Noncompliant
+
+        event MyDelegate MyEvent; // Noncompliant
+        unsafe event MyDelegate MyEvent2
+        {
+            add
+            {
+                int* p;
+            }
+            remove { }
+        }
+
+        ~Class4() // Noncompliant
+        {
+        }
+        void M()
+        {
+            Point pt = new Point();
+            unsafe
+            {
+                fixed (int* p = &pt.x)
+                {
+                    *p = 1;
+                }
+            }
+
+            unsafe
+            {
+                var i = 1;
+                int* p = &i;
+            }
+        }
+    }
+
+    public class Foo
+    {
+        public class Bar
+        {
+            public class Baz // Noncompliant
+            {
+            }
+        }
+    }
+
+    public unsafe class Foo2
+    {
+        public class Bar // Noncompliant
+        {
+            private int* p;
+
+            public class Baz // Noncompliant
+            {
+                private int* p2;
+            }
+        }
+    }
 }

--- a/src/Tests/SonarLint.UnitTest/TestCases/RedundantModifier.cs
+++ b/src/Tests/SonarLint.UnitTest/TestCases/RedundantModifier.cs
@@ -49,4 +49,94 @@ partial interface PartialInterface //Noncompliant
             return "Test";
         }
     }
+
+    unsafe class UnsafeClass
+    {
+        int* pointer;
+    }
+
+    unsafe class UnsafeClass2 // Noncompliant
+    {
+        int num;
+    }
+    unsafe class UnsafeClass3 // Noncompliant
+    {
+        unsafe void M() // Noncompliant
+        {
+
+        }
+    }
+
+    class Class4
+    {
+        unsafe interface MyInterface
+        {
+            unsafe int* Method(); // Noncompliant
+        }
+
+        private unsafe delegate void MyDelegate(int* p);
+        private unsafe delegate void MyDelegate2(int i); // Noncompliant
+
+        unsafe class Inner { } // Noncompliant
+
+        unsafe event MyDelegate MyEvent; // Noncompliant
+        unsafe event MyDelegate MyEvent2
+        {
+            add
+            {
+                int* p;
+            }
+            remove { }
+        }
+
+        unsafe ~Class4() // Noncompliant
+        {
+        }
+        void M()
+        {
+            Point pt = new Point();
+            unsafe
+            {
+                fixed (int* p = &pt.x)
+                {
+                    *p = 1;
+                }
+            }
+
+            unsafe
+            {
+                unsafe // Noncompliant
+                {
+                    unsafe // Noncompliant
+                    {
+                        var i = 1;
+                        int* p = &i;
+                    }
+                }
+            }
+        }
+    }
+
+    public class Foo
+    {
+        public class Bar
+        {
+            public unsafe class Baz // Noncompliant
+            {
+            }
+        }
+    }
+
+    public unsafe class Foo2
+    {
+        public unsafe class Bar // Noncompliant
+        {
+            private int* p;
+
+            public unsafe class Baz // Noncompliant
+            {
+                private int* p2;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Note: there's also https://jira.sonarsource.com/browse/SLVS-774 to enable this rule by default.